### PR TITLE
Get CommandLineInterface to compile. Fix resolver

### DIFF
--- a/subprojects/argbinder/source/jcli/argbinder/binder.d
+++ b/subprojects/argbinder/source/jcli/argbinder/binder.d
@@ -51,7 +51,8 @@ template bindArgument(Binders...)
                 return fail!void(validationResult.error, validationResult.errorCode);
         }}
 
-        ResultOf!ArgumentType conversionResult = conversionFunction(stringValue);
+        ResultOf!ArgumentType conversionResult; // Declared here first in order for opAssign to be called.
+        conversionResult = conversionFunction(stringValue);
         if (!conversionResult.isOk)
             return fail!void(conversionResult.error, conversionResult.errorCode);
 

--- a/subprojects/core/source/jcli/core/result.d
+++ b/subprojects/core/source/jcli/core/result.d
@@ -1,7 +1,10 @@
 module jcli.core.result;
 
+
 struct ResultOf(alias T)
 {
+    import std.typecons : Nullable;
+
     enum IsVoid = is(T == void);
     alias This = typeof(this);
 
@@ -39,6 +42,14 @@ struct ResultOf(alias T)
         t._error = error;
         t._errorCode = errorCode;
         return t;
+    }
+
+    static if(!is(T == void) && is(T : Nullable!DataT, DataT))
+    void opAssign(inout ResultOf!DataT notNullResult)
+    {
+        this._error = notNullResult._error;
+        this._errorCode = notNullResult._errorCode;
+        this._value = notNullResult._value;
     }
 
     inout:

--- a/subprojects/helptext/source/jcli/helptext/helptext.d
+++ b/subprojects/helptext/source/jcli/helptext/helptext.d
@@ -44,7 +44,7 @@ struct CommandHelpText(alias CommandT_)
         static foreach(i, nam; ArgumentInfo.named)
         {
             named ~= Arg(
-                patternToNamedArgList(nam.pattern),
+                patternToNamedArgList(cast()nam.pattern),
                 nam.description,
                 nam.group,
                 nam.flags.has(ArgFlags._optionalBit)


### PR DESCRIPTION
The issue with the resolver was that `CommandLineInterface.getCommand` was dummied out, so the resolver wasn't being populated with commands.

The ultimate issue though was getting CommandLineInterface to compile in the first place, which I've managed to get done.